### PR TITLE
Automatically create the /etc/ssh dir

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,11 @@ if [ ! -d "$HOME/.ssh" ]; then
   mkdir -p $HOME/.ssh
 fi
 
+if [ ! -d "/etc/ssh" ]; then
+  debug "/etc/ssh does not exists, creating it"
+  mkdir -p /etc/ssh
+fi
+
 # Write to system wide file by default
 known_hosts_path="/etc/ssh/ssh_known_hosts"
 


### PR DESCRIPTION
This change automatically creates the shared SSH dir ```/etc/ssh``` to prevent errors in images / containers that do not pre allocate this directory and failing with ```touch: cannot touch '/etc/ssh/ssh_known_hosts': No such file or directory```