### PR TITLE
Add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ the correct fingerprint (https://confluence.atlassian.com/bitbucket/use-the-ssh-
 * `type` (optional) Scan for these key types (default: `rsa,dsa,ecdsa`).
 * `port` (optional) Probe the ssh server on the following port.
 * `local` (optional) Set to `true` to add the host to `$HOME/.ssh/known_hosts` file instead of `/etc/ssh/ssh_known_hosts` (default: `false`).
+* `timeout` (optional) Set timeout for connection attempts in `ssh-keyscan` (default: `10` seconds).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ SHA256/base64 format:
 * `type` (optional) Scan for these key types (default: `rsa,dsa,ecdsa`).
 * `port` (optional) Probe the ssh server on the following port.
 * `local` (optional) Set to `true` to add the host to `$HOME/.ssh/known_hosts` file instead of `/etc/ssh/ssh_known_hosts` (default: `false`).
-* `timeout` (optional) Set timeout for connection attempts in `ssh-keyscan` (default: `10` seconds).
+* `timeout` (optional) Set the timeout for connection attempts in `ssh-keyscan`.
 * `use-md5` (optional) Set to `true` to use `MD5/hex` format for the key
 fingerprint. Please note that if you are using OpenSSH version equal or
 greater than 6.8 the fingerprint are reported in `SHA256/base64` format by

--- a/run.sh
+++ b/run.sh
@@ -37,6 +37,12 @@ else
   types="rsa,dsa,ecdsa"
 fi
 
+if [ -n "$WERCKER_ADD_TO_KNOWN_HOSTS_TIMEOUT" ]; then
+  timeout="$WERCKER_ADD_TO_KNOWN_HOSTS_TIMEOUT"
+else
+  timeout=10
+fi
+
 # Check if ssh-keyscan command exists
 set +e
 hash ssh-keyscan 2>/dev/null
@@ -47,7 +53,7 @@ if [ $result -ne 0 ] ; then
   fail "ssh-keyscan command not found. Cause: ssh-client software probably not installed."
 fi
 
-ssh_keyscan_command="ssh-keyscan -t $types"
+ssh_keyscan_command="ssh-keyscan -t $types -T $timeout"
 
 
 if [ ! -n "$WERCKER_ADD_TO_KNOWN_HOSTS_PORT" ] ; then

--- a/run.sh
+++ b/run.sh
@@ -73,7 +73,7 @@ else
   cat "$ssh_keyscan_result" | sed "/^ *#/d;s/#.*//" | while read ssh_key; do
     ssh_key_path=$(mktemp)
     echo "$ssh_key" > "$ssh_key_path"
-    ssh_key_fingerprint=$(ssh-keygen -l -f "$ssh_key_path" | awk '{print $2}')
+    ssh_key_fingerprint=$(ssh-keygen -l -f "$ssh_key_path" -E md5 | awk '{print $2}')
     if echo "$ssh_key_fingerprint" | grep -q "$WERCKER_ADD_TO_KNOWN_HOSTS_FINGERPRINT" ; then
       debug "Added a key to $known_hosts_path"
       echo "$ssh_key" | sudo tee -a "$known_hosts_path"

--- a/run.sh
+++ b/run.sh
@@ -37,12 +37,6 @@ else
   types="rsa,dsa,ecdsa"
 fi
 
-if [ -n "$WERCKER_ADD_TO_KNOWN_HOSTS_TIMEOUT" ]; then
-  timeout="$WERCKER_ADD_TO_KNOWN_HOSTS_TIMEOUT"
-else
-  timeout=10
-fi
-
 # Check if ssh-keyscan command exists
 set +e
 hash ssh-keyscan 2>/dev/null
@@ -53,8 +47,11 @@ if [ $result -ne 0 ] ; then
   fail "ssh-keyscan command not found. Cause: ssh-client software probably not installed."
 fi
 
-ssh_keyscan_command="ssh-keyscan -t $types -T $timeout"
+ssh_keyscan_command="ssh-keyscan -t $types"
 
+if [ -n "$WERCKER_ADD_TO_KNOWN_HOSTS_TIMEOUT" ]; then
+  ssh_keyscan_command="$ssh_keyscan_command -T $WERCKER_ADD_TO_KNOWN_HOSTS_TIMEOUT"
+fi
 
 if [ ! -n "$WERCKER_ADD_TO_KNOWN_HOSTS_PORT" ] ; then
     ssh_keyscan_command="$ssh_keyscan_command $WERCKER_ADD_TO_KNOWN_HOSTS_HOSTNAME"


### PR DESCRIPTION
I've often experienced random failures due to timeout of `ssh-keyscan` especially when bitbucket.org is slow. (discussed in https://github.com/wercker/step-add-to-known_hosts/issues/9)
This change is adding `timeout` option for users to adjust this timeout option.