### PR TITLE
Release 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## Changelog
 
+### 2.1.0
+- Add the `timeout` option to set the timeout for connection attempts in
+`ssh-keyscan` command.
+
 ### 2.0.4
-- Add the `use-md5` option to force the use of the `-E` flag in the ssh-keygen command.
+- Add the `use-md5` option to force the use of the `-E` flag in the `ssh-keygen` command.
 
 ### 2.0.3
 - bug fix: Add the `-E` flag to the ssh-keygen command to report the fingerprint in the `MD5/hex` format.

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: add-to-known_hosts
-version: 2.0.4
+version: 2.1.0
 description: A wercker step to use ssh-keyscan to add a host to the known_hosts file.
 keywords:
   - ssh-keygen


### PR DESCRIPTION
In this release there is a new optional flag to specify the timeout
parameter for the ssh-keyscan command.